### PR TITLE
Ensure that only  and  are the fields avaiablew for FormData admin

### DIFF
--- a/formfactory/admin.py
+++ b/formfactory/admin.py
@@ -47,7 +47,7 @@ class FormDataAdmin(admin.ModelAdmin):
     form = forms.FormDataAdminForm
     model = models.FormData
     inlines = [FormDataItemInline]
-    readonly_fields = utils.get_all_model_fields(models.FormData)
+    readonly_fields = ("form", "uuid")
 
 
 admin.site.register(models.Action, ActionModelAdmin)


### PR DESCRIPTION
Currently `FormDataAdmin` lists all its fields as readonly.
However, the `items` field on the model causes issue described in the issue.
This will resolve #23.