### PR TITLE
Change ordering of input error message

### DIFF
--- a/formfactory/factory.py
+++ b/formfactory/factory.py
@@ -123,10 +123,6 @@ class FormFactory(forms.Form):
                     field.label
                 bf = self[name]
 
-                # Escape and cache in local variable.
-                bf_errors = self.error_class(
-                    [conditional_escape(error) for error in bf.errors]
-                )
                 if not bf.is_hidden:
                     # Create a 'class="..."' atribute if the row should have
                     # any CSS classes applied.
@@ -160,6 +156,11 @@ class FormFactory(forms.Form):
                         "html_class_attr": html_class_attr,
                         "field_id": "id_%s" % name
                     })
+
+                # Escape and cache in local variable.
+                bf_errors = self.error_class(
+                    [conditional_escape(error) for error in bf.errors]
+                )
 
             output.append("</fieldset>")
 


### PR DESCRIPTION
Most of the designs we work from have error messages below input fields.