### PR TITLE
Add `show_title` to FormFieldGroup admin

### DIFF
--- a/formfactory/forms.py
+++ b/formfactory/forms.py
@@ -69,7 +69,7 @@ class WizardActionThroughAdminForm(forms.ModelForm):
 class FormFieldGroupAdminForm(forms.ModelForm):
     class Meta(object):
         model = models.FormFieldGroup
-        fields = ["title", "forms"]
+        fields = ["title", "show_title", "forms"]
 
 
 class FieldGroupFormThroughAdminForm(forms.ModelForm):

--- a/formfactory/views.py
+++ b/formfactory/views.py
@@ -151,7 +151,7 @@ class FactoryWizardView(NamedUrlSessionWizardView):
         context = super(FactoryWizardView, self).get_context_data(
             form, **kwargs)
         context["form_object"] = self.form_list_map[self.steps.current]
-        context["wizard_slug"] = self.wizard_object.slug
+        context["wizard_object"] = self.wizard_object
         return context
 
     def get_template_names(self):

--- a/formfactory/views.py
+++ b/formfactory/views.py
@@ -151,6 +151,7 @@ class FactoryWizardView(NamedUrlSessionWizardView):
         context = super(FactoryWizardView, self).get_context_data(
             form, **kwargs)
         context["form_object"] = self.form_list_map[self.steps.current]
+        context["wizard_slug"] = self.wizard_object.slug
         return context
 
     def get_template_names(self):

--- a/formfactory/views.py
+++ b/formfactory/views.py
@@ -147,6 +147,12 @@ class FactoryWizardView(NamedUrlSessionWizardView):
                 self.request.GET.get(redirect_name)
         return super(FactoryWizardView, self).get(*args, **kwargs)
 
+    def get_context_data(self, form, **kwargs):
+        context = super(FactoryWizardView, self).get_context_data(
+            form, **kwargs)
+        context["form_object"] = self.form_list_map[self.steps.current]
+        return context
+
     def get_template_names(self):
         return [
             "formfactory/wizard_%s_step.html" % self.steps.current,


### PR DESCRIPTION
Add `show_title` field to FormFieldGroup admin.

Add `form_object` and `wizard_object.slug` to view `context` so that `form`'s title can be used, and `wizard`'s slug can be used to reverse URLs in templates.